### PR TITLE
feat: add theme toggle scaffolding

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,12 +20,15 @@ array of panel definitions (type, key path, labels). Panel types: counter, toggl
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="bg-gray-50">
-  <div class="min-h-screen">
-    <header class="sticky top-0 z-40 bg-white/80 backdrop-blur border-b border-gray-200">
-      <div class="max-w-7xl mx-auto px-4 py-3">
-        <h1 class="text-xl font-semibold text-gray-800">D&D Character Tracker</h1>
-      </div>
-    </header>
+    <div class="min-h-screen">
+      <header class="sticky top-0 z-40 bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-gray-200 dark:border-slate-700">
+        <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
+          <h1 class="text-xl font-semibold text-gray-800 dark:text-slate-100">D&D Character Tracker</h1>
+          <div class="flex items-center gap-2">
+            <button id="themeToggle" type="button" class="chip-btn" aria-label="Toggle theme">Theme</button>
+          </div>
+        </div>
+      </header>
 
     <main class="max-w-7xl mx-auto px-4 py-6">
       <!-- Responsive grid: 1 col (phone), 2 cols (md), 3 cols (xl) -->
@@ -33,20 +36,21 @@ array of panel definitions (type, key path, labels). Panel types: counter, toggl
            class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 auto-rows-max">
       </div>
     </main>
-  </div>
+    </div>
 
-  <div id="toastRoot" class="fixed bottom-4 right-4 space-y-2 z-50"></div>
-  <div id="modalRoot" class="fixed inset-0 hidden items-center justify-center bg-black/30 z-40">
-    <div class="bg-white rounded-xl shadow p-4 w-80">
-      <h3 id="modalTitle" class="font-semibold mb-2">Confirm</h3>
-      <p id="modalBody" class="text-sm text-gray-700 mb-3"></p>
-      <div class="flex justify-end gap-2">
-        <button id="modalCancel" type="button" class="chip-btn">Cancel</button>
-        <button id="modalOk" type="button" class="chip-btn">OK</button>
+    <div id="toastRoot" class="fixed bottom-4 right-4 space-y-2 z-50" aria-live="polite"></div>
+
+    <div id="modalRoot" class="fixed inset-0 hidden items-center justify-center bg-black/30 z-40">
+      <div class="bg-white dark:bg-slate-900 rounded-xl shadow p-4 w-80 border border-gray-200 dark:border-slate-700">
+        <h3 id="modalTitle" class="font-semibold mb-2 text-gray-900 dark:text-slate-100">Confirm</h3>
+        <p id="modalBody" class="text-sm text-gray-700 dark:text-slate-300 mb-3"></p>
+        <div class="flex justify-end gap-2">
+          <button id="modalCancel" type="button" class="chip-btn">Cancel</button>
+          <button id="modalOk" type="button" class="chip-btn">OK</button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <script src="app.js"></script>
-</body>
-</html>
+    <script src="app.js"></script>
+  </body>
+  </html>

--- a/styles.css
+++ b/styles.css
@@ -3,30 +3,49 @@ input[type=number] { -moz-appearance:textfield; }
 input[type=number]::-webkit-inner-spin-button,
 input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
 
-.chip-btn {
-  padding: 0.375rem 0.75rem;
-  border-radius: 9999px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  transition: transform .05s ease, background .15s ease;
-}
-.chip-btn:hover { background: #e5e7eb; }
-.chip-btn:active { transform: translateY(1px); }
-
-.pulse-change { animation: pulse 400ms ease; }
-@keyframes pulse {
-  0% { background: #fef3c7; }
-  100% { background: transparent; }
-}
-
+/* ---- Controls ---- */
 .input {
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  border: 1px solid #d1d5db;
-  background-color: #fff;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  background: #fff;
+  transition: box-shadow .15s, border-color .15s;
 }
 .input:focus {
   outline: none;
   border-color: #6366f1;
-  box-shadow: 0 0 0 2px rgba(99,102,241,0.5);
+  box-shadow: 0 0 0 3px rgba(99,102,241,.25);
 }
+
+.chip-btn {
+  padding: 0.35rem 0.7rem;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  background: #f3f4f6;
+  transition: transform .05s ease, background .15s ease, border-color .15s ease;
+}
+.chip-btn:hover { background:#e5e7eb; }
+.chip-btn:active { transform: translateY(1px); }
+.chip-btn:focus { outline: none; box-shadow: 0 0 0 3px rgba(99,102,241,.25); }
+
+/* ---- Micro-interactions ---- */
+.pulse-change { animation: pulse-bg 420ms ease; }
+@keyframes pulse-bg {
+  0%   { background: #fef3c7; }
+  100% { background: transparent; }
+}
+
+/* ---- Collapsible animation (max-height trick) ---- */
+.collapsible {
+  overflow: hidden;
+  transition: max-height .25s ease, opacity .2s ease;
+}
+.collapsible.collapsed {
+  max-height: 0 !important;
+  opacity: 0;
+}
+
+/* ---- Dark mode tweaks (Tailwind "class" mode) ---- */
+:root { color-scheme: light dark; }
+.dark .input { border-color:#334155; background:#0b1220; color:#e5e7eb; }
+.dark .chip-btn { background:#0f172a; border-color:#1f2937; color:#e5e7eb; }


### PR DESCRIPTION
## Summary
- add theme toggle button in header and placeholders for toast and modal roots
- introduce reusable control styles and dark mode tweaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c6aba88c8332aefc4e95f5fc1798