### PR TITLE
Fix theme toggle and text colors

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,6 +98,25 @@ const CLASS_CONFIG = {
 
 let character = loadCharacter();
 
+function setTheme(mode) {
+  const root = document.documentElement;
+  if (mode === 'dark') root.classList.add('dark');
+  else root.classList.remove('dark');
+  localStorage.setItem('theme', mode);
+}
+
+function initTheme() {
+  const saved = localStorage.getItem('theme') || 'light';
+  setTheme(saved);
+  const btn = document.getElementById('themeToggle');
+  if (btn) {
+    btn.onclick = () => {
+      const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+      setTheme(next);
+    };
+  }
+}
+
 // Utility helpers
 function abilityMod(score) {
   return Math.floor((score - 10) / 2);
@@ -164,9 +183,9 @@ function panelWrap(id, title, bodyHTML, opts = {}) {
   const { span = 'col-span-1 md:col-span-1 xl:col-span-1', order = '' } = opts;
   return el(`
     <section id="${id}" class="${span} ${order} min-w-0">
-      <div class="bg-white p-4 rounded-xl shadow border border-gray-100">
-        <h2 class="font-semibold text-gray-800 text-lg mb-3">${title}</h2>
-        <div class="panel-body">${bodyHTML}</div>
+      <div class="bg-white dark:bg-slate-900 p-4 rounded-xl shadow border border-gray-100 dark:border-slate-800">
+        <h2 class="font-semibold text-gray-800 dark:text-slate-100 text-lg mb-3">${title}</h2>
+        <div class="panel-body text-gray-700 dark:text-slate-200">${bodyHTML}</div>
       </div>
     </section>
   `);
@@ -175,7 +194,7 @@ function panelWrap(id, title, bodyHTML, opts = {}) {
 function toast(msg) {
   const root = document.getElementById('toastRoot');
   const t = document.createElement('div');
-  t.className = 'px-3 py-2 rounded-lg shadow bg-gray-900 text-white text-sm';
+  t.className = 'px-3 py-2 rounded-lg shadow bg-gray-900 text-slate-100 text-sm';
   t.textContent = msg;
   root.appendChild(t);
   setTimeout(() => { t.remove(); }, 1600);
@@ -238,11 +257,11 @@ function buildHPPanel() {
   const barColor = pct >= 60 ? 'bg-green-500' : pct >= 30 ? 'bg-amber-500' : 'bg-red-500';
   const html = `
     <div class="flex flex-wrap items-center gap-3">
-      <div class="text-sm text-gray-600">Max</div>
+      <div class="text-sm text-gray-600 dark:text-slate-300">Max</div>
       <input id="hpMax" type="number" class="w-20 input" value="${hp.max}">
-      <div class="text-sm text-gray-600">Current</div>
+      <div class="text-sm text-gray-600 dark:text-slate-300">Current</div>
       <input id="hpCur" type="number" class="w-20 input" value="${hp.current}">
-      <div class="text-sm text-gray-600">Temp</div>
+      <div class="text-sm text-gray-600 dark:text-slate-300">Temp</div>
       <input id="hpTemp" type="number" class="w-20 input" value="${hp.temp}">
       <div class="flex items-center gap-1 ml-auto">
         <button type="button" class="chip-btn" data-d="-5">−5</button>
@@ -256,7 +275,7 @@ function buildHPPanel() {
       <div class="h-2 bg-gray-200 rounded">
         <div class="h-2 rounded ${barColor}" style="width:${pct}%"></div>
       </div>
-      <div class="text-xs text-gray-600 mt-1">${hp.current}/${hp.max} (+${hp.temp} temp)</div>
+      <div class="text-xs text-gray-600 dark:text-slate-300 mt-1">${hp.current}/${hp.max} (+${hp.temp} temp)</div>
     </div>
 
     <div class="mt-3">Hit Dice: <span id="hitDice">${character.combat.hitDice.remaining}/${character.combat.hitDice.total} ${character.combat.hitDice.die}</span>
@@ -664,5 +683,7 @@ document.addEventListener('keydown', e => {
   }
 });
 
-// Initial render
-render();
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  render();
+});

--- a/index.html
+++ b/index.html
@@ -17,9 +17,12 @@ array of panel definitions (type, key path, labels). Panel types: counter, toggl
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D&D Character Tracker</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = { darkMode: 'class' };
+  </script>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="bg-gray-50">
+<body class="bg-gray-50 text-gray-800 dark:text-slate-100">
     <div class="min-h-screen">
       <header class="sticky top-0 z-40 bg-white/80 dark:bg-slate-900/80 backdrop-blur border-b border-gray-200 dark:border-slate-700">
         <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
@@ -41,9 +44,9 @@ array of panel definitions (type, key path, labels). Panel types: counter, toggl
     <div id="toastRoot" class="fixed bottom-4 right-4 space-y-2 z-50" aria-live="polite"></div>
 
     <div id="modalRoot" class="fixed inset-0 hidden items-center justify-center bg-black/30 z-40">
-      <div class="bg-white dark:bg-slate-900 rounded-xl shadow p-4 w-80 border border-gray-200 dark:border-slate-700">
+      <div class="bg-white dark:bg-slate-900 rounded-xl shadow p-4 w-80 border border-gray-100 dark:border-slate-800">
         <h3 id="modalTitle" class="font-semibold mb-2 text-gray-900 dark:text-slate-100">Confirm</h3>
-        <p id="modalBody" class="text-sm text-gray-700 dark:text-slate-300 mb-3"></p>
+        <p id="modalBody" class="text-sm text-gray-700 dark:text-slate-200 mb-3"></p>
         <div class="flex justify-end gap-2">
           <button id="modalCancel" type="button" class="chip-btn">Cancel</button>
           <button id="modalOk" type="button" class="chip-btn">OK</button>

--- a/styles.css
+++ b/styles.css
@@ -9,12 +9,26 @@ input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin
   border-radius: 0.5rem;
   border: 1px solid #e5e7eb;
   background: #fff;
+  color: #111827;
   transition: box-shadow .15s, border-color .15s;
 }
 .input:focus {
   outline: none;
   border-color: #6366f1;
   box-shadow: 0 0 0 3px rgba(99,102,241,.25);
+}
+
+/* Restore native look */
+input[type="checkbox"] {
+  appearance: auto;
+  -webkit-appearance: checkbox;
+  -moz-appearance: checkbox;
+  accent-color: #4f46e5;
+}
+
+/* High-contrast color in dark mode */
+.dark input[type="checkbox"] {
+  accent-color: #a5b4fc;
 }
 
 .chip-btn {


### PR DESCRIPTION
## Summary
- enable class-based dark mode and add theme toggle logic
- update panel styles and text colors for light/dark modes
- restore native checkbox appearance and input readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cc01c6fc83328440949fc54c28b4